### PR TITLE
Implemented writing of include guard header string

### DIFF
--- a/holberton-project-scraper.py
+++ b/holberton-project-scraper.py
@@ -4,6 +4,7 @@ import mechanize
 import sys
 import re
 import json
+import string
 from bs4 import BeautifulSoup
 
 # fill in prototype in each file
@@ -25,7 +26,7 @@ if count != 2:
         sys.exit()
 
 # Intranet login credentials
-with open("/CHANGE_TO_YOUR_DIRECTORY_HERE/auth_data.json", "r") as my_keys:
+with open("/home/vagrant/holberton-python-scripts/auth_data.json", "r") as my_keys:
         intra_keys = json.load(my_keys)
 
 
@@ -66,10 +67,11 @@ for li in find_file_name:
 	if (i == len(proto_store)):
 		break;
         store_file_name = open(li.next_sibling.text, "w+")
-        store_file_name.write('#include "%s"\n' % sys.argv[2])
+        store_file_name.write('#include "%s"\n\n' % sys.argv[2])
         store_file_name.write("/**\n")
-        store_file_name.write(" * main - Entry Point\n")   
-        store_file_name.write(" * Return: 0\n")
+        store_file_name.write(" * main - Entry Point\n")
+	store_file_name.write(" *\n")
+        store_file_name.write(" * Return:\n")
         store_file_name.write(" */\n")
         store_file_name.write("%s\n" % proto_store[i])
         store_file_name.write("{\n")
@@ -86,13 +88,16 @@ find_proto_h = soup.find_all(string=re.compile("Prototype: "))
 for li in find_proto_h:
         proto_h_store.append(li.next_sibling.text)
 
+# Making header include guard string
+include_guard = sys.argv[2]
+include_guard = include_guard.replace('.', '_', 1)
+include_guard = include_guard.upper()
+
 # Making header file
 make_header = open(sys.argv[2], "w+")
-make_header.write("#ifndef\n")
-make_header.write("#define\n")
+make_header.write('#ifndef %s\n' % include_guard)
+make_header.write('#define %s\n' % include_guard)
 make_header.write("\n")
-make_header.write("#include <stdio.h>\n")
-make_header.write("#include <stdlib.h>\n")
 make_header.write("\n")
 make_header.write("int _putchar(char c);\n")
 
@@ -104,5 +109,4 @@ for li in find_proto_h:
         n += 1
 
 make_header.write("\n")
-make_header.write("#endif /* */")
-
+make_header.write('#endif /* %s */' % include_guard)

--- a/holberton-project-scraper.py
+++ b/holberton-project-scraper.py
@@ -26,7 +26,7 @@ if count != 2:
         sys.exit()
 
 # Intranet login credentials
-with open("/home/vagrant/holberton-python-scripts/auth_data.json", "r") as my_keys:
+with open("/CHANGE_TO_YOUR_DIRECTORY_HERE/auth_data.json", "r") as my_keys:
         intra_keys = json.load(my_keys)
 
 


### PR DESCRIPTION
New `# Making header include guard string` that creates the necessary include guard and writes it into the header file. Also, added new line spacing between include directives and function documentation in C files.